### PR TITLE
chunk_duration_sec added

### DIFF
--- a/examples/scheme2/toy_example.py
+++ b/examples/scheme2/toy_example.py
@@ -26,7 +26,8 @@ def main():
             phase1_detect_channel_radius=150,
             detect_channel_radius=50,
             training_duration_sec=60
-        )
+        ),
+        chunk_duration_sec=20
     )
     
     elapsed_sec = time.time() - timer

--- a/mountainsort5/schemes/sorting_scheme2.py
+++ b/mountainsort5/schemes/sorting_scheme2.py
@@ -21,7 +21,7 @@ def sorting_scheme2(
     return_snippet_classifiers: bool = False, # used in scheme 3
     reference_snippet_classifiers: Union[Dict[int, SnippetClassifier], None] = None, # used in scheme 3
     label_offset: int = 0, # used in scheme 3
-    chunk_duration_sec: Union[float, None] = 10.0 
+    chunk_duration_sec: float = 10.0 
 ) -> Union[si.BaseSorting, Tuple[si.BaseSorting, Dict[int, SnippetClassifier]]]:
     """MountainSort 5 sorting scheme 2
 

--- a/mountainsort5/schemes/sorting_scheme2.py
+++ b/mountainsort5/schemes/sorting_scheme2.py
@@ -19,7 +19,8 @@ def sorting_scheme2(
     sorting_parameters: Scheme2SortingParameters,
     return_snippet_classifiers: bool = False, # used in scheme 3
     reference_snippet_classifiers: Union[Dict[int, SnippetClassifier], None] = None, # used in scheme 3
-    label_offset: int = 0 # used in scheme 3
+    label_offset: int = 0, # used in scheme 3
+    chunk_duration_sec: Union[float, None] = 10.0 
 ) -> Union[si.BaseSorting, Tuple[si.BaseSorting, Dict[int, SnippetClassifier]]]:
     """MountainSort 5 sorting scheme 2
 
@@ -29,6 +30,7 @@ def sorting_scheme2(
         return_snippet_classifiers (bool): whether to return the snippet classifiers (used in scheme 3)
         reference_snippet_classifiers: used in scheme 3
         label_offset: used in scheme 3
+        chunk_duration_sec: length of each chunk during inference
 
     Returns:
         si.BaseSorting: SpikeInterface sorting object
@@ -172,7 +174,8 @@ def sorting_scheme2(
 
     # Now that we have the classifier, we can do the full sorting
     # Iterate over time chunks, detect and classify all spikes, and collect the results
-    chunk_size = int(math.ceil(100e6 / recording.get_num_channels())) # size of chunks in samples
+    chunk_size = int(math.ceil(chunk_duration_sec * sampling_frequency))
+
     print(f'Chunk size: {chunk_size / recording.sampling_frequency} sec')
     chunks = get_time_chunks(recording.get_num_samples(), chunk_size=chunk_size, padding=1000)
     times_list: list[npt.NDArray[np.int64]] = []


### PR DESCRIPTION
Add chunk_duration_sec argument to scheme2 to allow user to use more RAM during second phase of scheme2. With a recording object that was saved to disk as binary and subsequently loaded, using `chunk_duration_sec=30` resulted in a 14  minute sort. Using `chunk_duration_sec=300` resulted in 8.5 minute sort.