### PR TITLE
Add cron for trying to build on Mac and Windows

### DIFF
--- a/.github/workflows/windows-mac-build
+++ b/.github/workflows/windows-mac-build
@@ -1,0 +1,32 @@
+name: Build and Install on Mac and Windows
+
+on:
+  schedule:
+    - cron: "0 12 * * 0" # weekly
+
+jobs:
+  build:
+    name: Build & Test on ${{ matrix.os }} OS
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+          python-version: '3.10'
+    - name: Install mountainsort
+      run: pip install -e .
+    - name: Install Packages needed by spikeinterface
+      run: pip install h5py pandas networkx
+    - name: Install packages needed for tests
+      run: pip install pytest pytest-cov
+    - name: Run tests
+      run: pytest

--- a/.github/workflows/windows-mac-build
+++ b/.github/workflows/windows-mac-build
@@ -29,4 +29,4 @@ jobs:
     - name: Install packages needed for tests
       run: pip install pytest pytest-cov
     - name: Run tests
-      run: pytest
+      run: pytest -- cov mountainsort5 --cov-report=xml --cov-report=term tests/


### PR DESCRIPTION
@magland 

I saw the issue with the mac build. This is just a draft action to build and test mountainsort5 on mac , windows and linux. If you want the cron to just build and see if it can successfully build the test part can be deleted. (I don't think GA test on M chips for macs, but users can also try to build the packages with rosetta if needed).