### PR TITLE
Add `classification_chunk_sec` to scheme 2 parameters

### DIFF
--- a/docs/scheme2.md
+++ b/docs/scheme2.md
@@ -106,6 +106,10 @@ The duration of the training data (in seconds). See also the `training_recording
 
 How to sample the training data. If 'initial', then the first training_duration_sec of the recording will be used. If 'uniform', then the training data will be sampled uniformly in 10-second chunks from the recording.
 
+**classification_chunk_sec**
+
+Amount of data (in seconds) loaded into memory at a time during the extraction / classification step of scheme 2
+
 ## Algorithm
 
 **Phase 1.** First, a subset of the recording is extracted for training, according to the `training_duration_sec` and `training_recording_sampling_mode` parameters. Then, scheme 1 detection and clustering is performed on this training subset.

--- a/mountainsort5/schemes/Scheme2SortingParameters.py
+++ b/mountainsort5/schemes/Scheme2SortingParameters.py
@@ -46,7 +46,7 @@ class Scheme2SortingParameters:
     classifier_npca: Union[int, None] = None
     training_duration_sec: Union[float, None] = None
     training_recording_sampling_mode: Literal['initial', 'uniform'] = 'initial'
-    classification_chunk_sec: float = 20.0
+    classification_chunk_sec: Union[float, None] = None
 
     def check_valid(self, *, M: int, N: int, sampling_frequency: float, channel_locations: npt.NDArray[np.float32]):
         """Internal function for checking validity of parameters"""

--- a/mountainsort5/schemes/Scheme2SortingParameters.py
+++ b/mountainsort5/schemes/Scheme2SortingParameters.py
@@ -26,6 +26,7 @@ class Scheme2SortingParameters:
     - classifier_npca: the number of principal components to use for each neighborhood classifier
     - training_duration_sec: the duration of the training data (in seconds)
     - training_recording_sampling_mode: how to sample the training data. If 'initial', then the first training_duration_sec of the recording will be used. If 'uniform', then the training data will be sampled uniformly in 10-second chunks from the recording.
+    - classification_chunk_sec: the duration of each chunk of data to use for classification (in seconds)
     """
     phase1_detect_channel_radius: Union[float, None]
     detect_channel_radius: Union[float, None]
@@ -45,6 +46,7 @@ class Scheme2SortingParameters:
     classifier_npca: Union[int, None] = None
     training_duration_sec: Union[float, None] = None
     training_recording_sampling_mode: Literal['initial', 'uniform'] = 'initial'
+    classification_chunk_sec: float = 20.0
 
     def check_valid(self, *, M: int, N: int, sampling_frequency: float, channel_locations: npt.NDArray[np.float32]):
         """Internal function for checking validity of parameters"""

--- a/mountainsort5/schemes/sorting_scheme2.py
+++ b/mountainsort5/schemes/sorting_scheme2.py
@@ -200,7 +200,8 @@ def sorting_scheme2(
 
     # Now that we have the classifier, we can do the full sorting
     # Iterate over time chunks, detect and classify all spikes, and collect the results
-    chunk_size = int(math.ceil(100e6 / recording.get_num_channels())) # size of chunks in samples
+    chunk_size = int(math.ceil(sorting_parameters.classification_chunk_sec * recording.sampling_frequency))
+
     print(f'Chunk size: {chunk_size / recording.sampling_frequency} sec')
     chunks = get_time_chunks(np.int64(recording.get_num_samples()), chunk_size=np.int32(chunk_size), padding=np.int32(1000))
     times_list: list[npt.NDArray[np.int64]] = []

--- a/mountainsort5/schemes/sorting_scheme2.py
+++ b/mountainsort5/schemes/sorting_scheme2.py
@@ -200,7 +200,11 @@ def sorting_scheme2(
 
     # Now that we have the classifier, we can do the full sorting
     # Iterate over time chunks, detect and classify all spikes, and collect the results
-    chunk_size = int(math.ceil(sorting_parameters.classification_chunk_sec * recording.sampling_frequency))
+
+    if sorting_parameters.classification_chunk_sec is None:
+        chunk_size = int(math.ceil(100e6 / recording.get_num_channels())) # size of chunks in samples
+    else:
+        chunk_size = int(math.ceil(sorting_parameters.classification_chunk_sec * recording.sampling_frequency))
 
     print(f'Chunk size: {chunk_size / recording.sampling_frequency} sec')
     chunks = get_time_chunks(np.int64(recording.get_num_samples()), chunk_size=np.int32(chunk_size), padding=np.int32(1000))


### PR DESCRIPTION
This provides an important knob for speeding up the sorting depending on how many spikes are detected. For example, for recordings with sparse spiking, it is inefficient to extract and classify on small chunks of data (because you are only loading a small number of spikes into memory at a time) and the sorting is bottlenecked by the speed at which the data can be loaded from disk. 