### PR TITLE
Remove `subdivision` from `Scheme2SortingParameters`

### DIFF
--- a/mountainsort5/schemes/Scheme2SortingParameters.py
+++ b/mountainsort5/schemes/Scheme2SortingParameters.py
@@ -35,7 +35,6 @@ class Scheme2SortingParameters:
     detect_time_radius_msec: float = 0.5
     phase1_npca_per_channel: int = 3
     phase1_npca_per_subdivision: int = 10
-    subdivision: int = 10
     phase1_pairwise_merge_step: bool = False # deprecated
     detect_sign: int = -1
     detect_threshold: float = 5.5


### PR DESCRIPTION
Seems like this argument is not used anywhere. It is also not described in `scheme2.md`. Perhaps redundant with `phase1_npca_per_subdivision`?