### PR TITLE
Add `svd_solver` to phase 1 sorter parameters

### DIFF
--- a/mountainsort5/core/compute_pca_features.py
+++ b/mountainsort5/core/compute_pca_features.py
@@ -32,5 +32,5 @@ def compute_pca_features(
     if L == 0 or D == 0:
         return np.zeros((0, npca_2), dtype=np.float32)
     pca = decomposition.PCA(n_components=npca_2, svd_solver=svd_solver)
-    print(pca.whiten)
+
     return pca.fit_transform(X)

--- a/mountainsort5/core/compute_pca_features.py
+++ b/mountainsort5/core/compute_pca_features.py
@@ -1,9 +1,14 @@
 import numpy as np
 import numpy.typing as npt
 from sklearn import decomposition
+from typing import Literal
 
-
-def compute_pca_features(X: npt.NDArray[np.float32], *, npca: int):
+def compute_pca_features(
+        X: npt.NDArray[np.float32],
+        *, 
+        npca: int, 
+        svd_solver: Literal['auto', 'full', 'covariance_eigh', 'arpack', 'randomized'] = 'auto'
+    ):
     """Compute PCA features.
 
     Parameters
@@ -13,6 +18,8 @@ def compute_pca_features(X: npt.NDArray[np.float32], *, npca: int):
         number of features.
     npca : int
         Number of PCA features to return.
+    svd_solver : 'auto', 'full', 'covariance_eigh', 'arpack' or 'randomized'.
+        Solver used by sklearn pca decomposition.
 
     Returns
     -------
@@ -24,5 +31,6 @@ def compute_pca_features(X: npt.NDArray[np.float32], *, npca: int):
     npca_2 = np.minimum(np.minimum(npca, L), D)
     if L == 0 or D == 0:
         return np.zeros((0, npca_2), dtype=np.float32)
-    pca = decomposition.PCA(n_components=npca_2)
+    pca = decomposition.PCA(n_components=npca_2, svd_solver=svd_solver)
+    print(pca.whiten)
     return pca.fit_transform(X)

--- a/mountainsort5/schemes/Scheme1SortingParameters.py
+++ b/mountainsort5/schemes/Scheme1SortingParameters.py
@@ -1,6 +1,6 @@
 import numpy as np
 import numpy.typing as npt
-from typing import Union
+from typing import Union, Literal
 from dataclasses import dataclass
 
 
@@ -17,6 +17,7 @@ class Scheme1SortingParameters:
     - npca_per_channel: the number of PCA components per channel for initial dimension reduction
     - npca_per_subdivision: the number of PCA components to compute for each subdivision of clustering
     - skip_alignment: whether to skip the alignment step (if None, then False)
+    - svd_solver: solver used in `sklearn`s pca decomposition. Can be 'auto', 'full', 'covariance_eigh', 'arpack' or 'randomized'.
     """
     detect_threshold: float = 5.5
     detect_channel_radius: Union[float, None] = None
@@ -29,6 +30,7 @@ class Scheme1SortingParameters:
     npca_per_subdivision: int = 10
     skip_alignment: Union[bool, None] = None
     pairwise_merge_step: bool = False # deprecated
+    svd_solver: Literal['auto', 'full', 'covariance_eigh', 'arpack', 'randomized'] = 'auto'
 
     def check_valid(self, *, M: int, N: int, sampling_frequency: float, channel_locations: npt.NDArray[np.float32]):
         """Internal function for checking validity of parameters"""

--- a/mountainsort5/schemes/Scheme2SortingParameters.py
+++ b/mountainsort5/schemes/Scheme2SortingParameters.py
@@ -27,6 +27,7 @@ class Scheme2SortingParameters:
     - training_duration_sec: the duration of the training data (in seconds)
     - training_recording_sampling_mode: how to sample the training data. If 'initial', then the first training_duration_sec of the recording will be used. If 'uniform', then the training data will be sampled uniformly in 10-second chunks from the recording.
     - classification_chunk_sec: the duration of each chunk of data to use for classification (in seconds)
+    - phase_1_svd_solver: svd_solver in phase 1
     """
     phase1_detect_channel_radius: Union[float, None]
     detect_channel_radius: Union[float, None]
@@ -46,6 +47,7 @@ class Scheme2SortingParameters:
     training_duration_sec: Union[float, None] = None
     training_recording_sampling_mode: Literal['initial', 'uniform'] = 'initial'
     classification_chunk_sec: Union[float, None] = None
+    phase1_svd_solver: Literal['auto', 'full', 'covariance_eigh', 'arpack', 'randomized'] = 'auto'
 
     def check_valid(self, *, M: int, N: int, sampling_frequency: float, channel_locations: npt.NDArray[np.float32]):
         """Internal function for checking validity of parameters"""

--- a/mountainsort5/schemes/Scheme2SortingParameters.py
+++ b/mountainsort5/schemes/Scheme2SortingParameters.py
@@ -47,7 +47,7 @@ class Scheme2SortingParameters:
     training_duration_sec: Union[float, None] = None
     training_recording_sampling_mode: Literal['initial', 'uniform'] = 'initial'
     classification_chunk_sec: Union[float, None] = None
-    phase1_svd_solver: Literal['auto', 'full', 'covariance_eigh', 'arpack', 'randomized'] = 'auto'
+    phase_1_svd_solver: Literal['auto', 'full', 'covariance_eigh', 'arpack', 'randomized'] = 'auto'
 
     def check_valid(self, *, M: int, N: int, sampling_frequency: float, channel_locations: npt.NDArray[np.float32]):
         """Internal function for checking validity of parameters"""

--- a/mountainsort5/schemes/sorting_scheme1.py
+++ b/mountainsort5/schemes/sorting_scheme1.py
@@ -107,7 +107,7 @@ def sorting_scheme1(
     npca = sorting_parameters.npca_per_channel * M
     print(f'Computing PCA features with npca={npca}')
     tt = Timer('compute_pca_features')
-    features = compute_pca_features(snippets.reshape((L, T * M)), npca=npca)
+    features = compute_pca_features(snippets.reshape((L, T * M)), npca=npca, svd_solver=sorting_parameters.svd_solver)
     tt.report()
 
     print(f'Isosplit6 clustering with npca_per_subdivision={sorting_parameters.npca_per_subdivision}')
@@ -147,7 +147,7 @@ def sorting_scheme1(
 
         print(f'Computing PCA features with npca={npca}')
         tt = Timer('compute_pca_features')
-        features = compute_pca_features(snippets.reshape((L, T * M)), npca=npca)
+        features = compute_pca_features(snippets.reshape((L, T * M)), npca=npca, svd_solver=sorting_parameters.svd_solver)
         tt.report()
 
         print(f'Isosplit6 clustering with npca_per_subdivision={sorting_parameters.npca_per_subdivision}')

--- a/mountainsort5/schemes/sorting_scheme2.py
+++ b/mountainsort5/schemes/sorting_scheme2.py
@@ -95,7 +95,9 @@ def sorting_scheme2(
             snippet_T1=sorting_parameters.snippet_T1,
             snippet_T2=sorting_parameters.snippet_T2,
             npca_per_channel=sorting_parameters.phase1_npca_per_channel,
-            npca_per_subdivision=sorting_parameters.phase1_npca_per_subdivision
+            npca_per_subdivision=sorting_parameters.phase1_npca_per_subdivision,
+            svd_solver=sorting_parameters.phase_1_svd_solver,
+
         )
     )
     assert isinstance(sorting1, si.BaseSorting)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,8 +13,9 @@ from mountainsort5.core.get_times_labels_from_sorting import get_times_labels_fr
 
 def test_compute_pca_features():
     x = np.random.normal(size=(100, 20)).astype(np.float32)
-    features = compute_pca_features(x, npca=10)
-    assert features.shape == (100, 10)
+    for svd_solver in ['auto', 'full', 'covariance_eigh', 'arpack', 'randomized']:
+        features = compute_pca_features(x, npca=10, svd_solver=svd_solver)
+        assert features.shape == (100, 10)
 
 def test_compute_templates():
     L = 1000


### PR DESCRIPTION
In #50, we discussed ways to speed up the `compute_pca_features` function in phase 1, which was the bottleneck for applying mountainsort5 my data.

When experimenting, I found that using the `covariance_eigh` algorithm for decomposition (https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html) sped things up a lot! This PR allows users to specify the `phase_1_svd_solver` parameter, but keeps the current default.

I don't have any solid benchmarks for saying that `covariance_eigh` works fine - but it works fine for my data!

Note that this does not get passed to `isosplit6_subdivision_method` because it takes a smaller subset of data, and the default method runs quickly.

If something like this gets merged, I can update the spikeinterface side too :) 