### PR TITLE
fixed np.Inf -> np.inf

### DIFF
--- a/mountainsort5/schemes/sorting_scheme1.py
+++ b/mountainsort5/schemes/sorting_scheme1.py
@@ -202,7 +202,7 @@ def sorting_scheme1(
     for k in range(1, K + 1):
         inds = np.where(labels == k)[0]
         if len(inds) == 0:
-            aa[k - 1] = np.Inf
+            aa[k - 1] = np.inf
     new_labels_mapping = np.argsort(np.argsort(aa)) + 1 # too tricky! my head aches right now
     labels = new_labels_mapping[labels - 1]
     tt.report()
@@ -271,7 +271,7 @@ def align_templates(templates: npt.NDArray[np.float32]):
 
 def compute_pairwise_optimal_offset(template1: npt.NDArray[np.float32], template2: npt.NDArray[np.float32]):
     T = template1.shape[0]
-    best_inner_product = -np.Inf
+    best_inner_product = -np.inf
     best_offset = 0
     for offset in range(T):
         inner_product = np.sum(np.roll(template1, shift=offset, axis=0) * template2)


### PR DESCRIPTION
Currently ms5 with numpy 2 throws the following error:

```
Traceback (most recent call last):
  File "/disk/scratch/nkudryas/StimIO/BlackRock_US_dataset/sort_MS.py", line 31, in <module>
    sorting = ms5.sorting_scheme2(
              ^^^^^^^^^^^^^^^^^^^^
  File "/disk/scratch/nkudryas/micromamba/envs/StimIO/lib/python3.12/site-packages/mountainsort5/schemes/sorting_scheme2.py", line 87, in sorting_scheme2
    sorting1 = sorting_scheme1(
               ^^^^^^^^^^^^^^^^
  File "/disk/scratch/nkudryas/micromamba/envs/StimIO/lib/python3.12/site-packages/mountainsort5/schemes/sorting_scheme1.py", line 135, in sorting_scheme1
    offsets = align_templates(templates)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/disk/scratch/nkudryas/micromamba/envs/StimIO/lib/python3.12/site-packages/mountainsort5/schemes/sorting_scheme1.py", line 244, in align_templates
    offset, inner_product = compute_pairwise_optimal_offset(templates[k1], templates[k2])
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/disk/scratch/nkudryas/micromamba/envs/StimIO/lib/python3.12/site-packages/mountainsort5/schemes/sorting_scheme1.py", line 274, in compute_pairwise_optimal_offset
    best_inner_product = -np.Inf
                          ^^^^^^
  File "/disk/scratch/nkudryas/micromamba/envs/StimIO/lib/python3.12/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.. Did you mean: 'inf'?
```

Versions:
numpy == 2.2.2
mountainsort5 == 0.5.6


