### PR TITLE
Support SpikeInterface's renamed private segment list (_segments)

### DIFF
--- a/mountainsort5/core/get_block_recording_for_scheme3.py
+++ b/mountainsort5/core/get_block_recording_for_scheme3.py
@@ -56,8 +56,13 @@ class BlockRecordingSegment(si.BaseRecordingSegment):
         if end_frame is None:
             end_frame = self.get_num_samples()
 
-        # Get the traces from the parent recording
-        return self._recording._recording_segments[0].get_traces(
+        # Get the traces from the parent recording.
+        # SpikeInterface renamed the private segment list from `_recording_segments`
+        # to `_segments`; support both so this works across SpikeInterface versions.
+        segments = getattr(self._recording, "_recording_segments", None)
+        if segments is None:
+            segments = self._recording._segments
+        return segments[0].get_traces(
             start_frame=start_frame + self._start_frame,
             end_frame=end_frame + self._start_frame,
             channel_indices=channel_indices


### PR DESCRIPTION
Trying to use Scheme 3's `BlockRecordingSegment.get_traces()` with newer versions of SpikeInterface raises an `AttributeError`, because recent versions of SpikeInterface have renamed `_recording_segments` to `_segments`.

This little patch checks if `_recording_segments` is present and, if not, tries to use `_segments` instead. So this should allow Scheme 3 to work across SpikeInterface versions.