### PR TITLE
Always use the most performant deterministic SVD solver available for PCA.

### DIFF
--- a/mountainsort5/core/SnippetClassifier.py
+++ b/mountainsort5/core/SnippetClassifier.py
@@ -1,9 +1,12 @@
-from typing import List, Tuple, Union, Dict
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Union
+
 import numpy as np
 import numpy.typing as npt
-from dataclasses import dataclass
 from sklearn import decomposition
 from sklearn.neighbors import NearestNeighbors
+
+from .pca_solver import deterministic_pca_solver
 
 
 class SnippetClassifier:
@@ -26,9 +29,12 @@ class SnippetClassifier:
             effective_npca = self.npca
         else:
             effective_npca = max(12, self.M * 3)
-        self.pca_model = decomposition.PCA(n_components=min(effective_npca, L))
-        self.pca_model.fit(all_training_snippets.reshape(L, self.T * self.M))
-        X = self.pca_model.transform(all_training_snippets.reshape(L, self.T * self.M))
+        n_features = self.T * self.M
+        n_components = min(effective_npca, L)
+        svd_solver = deterministic_pca_solver(L, n_features)
+        self.pca_model = decomposition.PCA(n_components=n_components, svd_solver=svd_solver, random_state=0)
+        self.pca_model.fit(all_training_snippets.reshape(L, n_features))
+        X = self.pca_model.transform(all_training_snippets.reshape(L, n_features))
         self.nearest_neighbor_model = NearestNeighbors(n_neighbors=2)
         self.nearest_neighbor_model.fit(X)
     def classify_snippets(self, snippets: npt.NDArray[np.float32]) -> Tuple[Union[npt.NDArray, None], Union[npt.NDArray, None]]:

--- a/mountainsort5/core/compute_pca_features.py
+++ b/mountainsort5/core/compute_pca_features.py
@@ -2,6 +2,8 @@ import numpy as np
 import numpy.typing as npt
 from sklearn import decomposition
 
+from .pca_solver import deterministic_pca_solver
+
 
 def compute_pca_features(X: npt.NDArray[np.float32], *, npca: int):
     """Compute PCA features.
@@ -24,5 +26,6 @@ def compute_pca_features(X: npt.NDArray[np.float32], *, npca: int):
     npca_2 = np.minimum(np.minimum(npca, L), D)
     if L == 0 or D == 0:
         return np.zeros((0, npca_2), dtype=np.float32)
-    pca = decomposition.PCA(n_components=npca_2)
+    solver = deterministic_pca_solver(int(L), int(D))
+    pca = decomposition.PCA(n_components=npca_2, svd_solver=solver, random_state=0)
     return pca.fit_transform(X)

--- a/mountainsort5/core/pca_solver.py
+++ b/mountainsort5/core/pca_solver.py
@@ -1,0 +1,47 @@
+"""Pick a deterministic sklearn PCA ``svd_solver``.
+
+sklearn's default ``svd_solver='auto'`` often selects the stochastic ``'randomized'``
+solver for both ``compute_pca_features`` during phase-1 clustering and
+``SnippetClassifier.fit`` during per-channel classifier construction, which makes
+sorting non-reproducible run to run on identical inputs if not seeded.
+
+We want:
+- ``'covariance_eigh'`` when ``n_features`` is modest and ``n_samples >= n_features``,
+  since it is exact, deterministic, and fastest in that regime. This regime virtually
+  always applies when fitting per-channel classifiers, regardless of whether we are
+  sorting tetrode data or Neuropixel data.
+- ``'full'`` when ``n_samples < n_features`` (and ``n_features`` is modest), since it is
+  exact, deterministic, numerically stable, and cheap (bounded by
+  ``min(n_samples, n_features)``). That said, this regime almost never applies.
+- ``'randomized'`` when ``n_features`` exceeds ``cov_cap``, since materializing the
+  ``n_features x n_features`` covariance matrix and its eigendecomposition is
+  impractical -- e.g. a whole-probe Neuropixels phase-1 PCA can have
+  ``n_features ~= 21k``. That's ~3.6 GB covariance and even more for the
+  eigendecomposition workspace, plus many minutes (tens) of compute. ``'randomized'`` is
+  what ``'auto'`` already picks in that case; Yes, it stays approximate, but seeding it
+  at least makes it deterministic.
+
+The ``cov_cap`` default of 8000 corresponds to a ~0.5 GB covariance matrix. It is a
+safety rail: realistic 64ch tetrode (``n_features ~= 160``) and Neuropixels
+(``n_features <~ 1600``) classifiers never approach it, and only the whole-probe
+``compute_pca_features`` call exceeds it.
+
+NOTE: callers MUST pass ``random_state=<int>`` to ``PCA`` so the ``'randomized'``
+branch is deterministic. ``random_state`` is ignored by the exact solvers, so it is
+safe to pass unconditionally.
+"""
+
+
+def deterministic_pca_solver(
+    n_samples: int, n_features: int, *, cov_cap: int = 8000
+) -> str:
+    """Return an sklearn PCA ``svd_solver`` that is never the unseeded ``'randomized'`` auto-pick.
+
+    See module docstring for the rationale. Callers must still pass ``random_state``
+    to ``PCA`` so the ``'randomized'`` branch (large ``n_features``) is reproducible.
+    """
+    if n_features > cov_cap:
+        return "randomized"
+    if n_samples >= n_features:
+        return "covariance_eigh"
+    return "full"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ from mountainsort5.core.get_sampled_recording_for_training import get_sampled_re
 from mountainsort5.core.get_block_recording_for_scheme3 import get_block_recording_for_scheme3
 from mountainsort5.core.isosplit6_subdivision_method import isosplit6_subdivision_method
 from mountainsort5.core.get_times_labels_from_sorting import get_times_labels_from_sorting
+from mountainsort5.core.SnippetClassifier import SnippetClassifier
 
 
 def test_compute_pca_features():
@@ -195,3 +196,64 @@ def test_get_times_labels_from_sorting():
     times2, labels2 = get_times_labels_from_sorting(sorting2)
     assert len(times2) == 0
     assert len(labels2) == 0
+
+def test_snippet_classifier_is_deterministic():
+    # The classifier must use an EXACT, deterministic PCA solver, not sklearn's
+    # stochastic 'randomized' (which 'auto' selects for 500 < n_samples < 10*n_features,
+    # the common per-classifier regime). Solver choice: 'covariance_eigh' when there are
+    # at least as many samples as features (L >= n_features), else exact 'full' SVD;
+    # both are deterministic. Verify the right exact solver is picked in each regime and
+    # that two fits on identical data give bit-identical PCA components.
+    rng = np.random.default_rng(1)
+    T, M = 40, 4
+    n_features = T * M  # 160
+
+    def fit_on(batch_sizes):
+        sc = SnippetClassifier(npca=None)
+        snips = [(rng.standard_normal((s, T, M)).astype(np.float32), lab) for lab, s in enumerate(batch_sizes)]
+        sc2 = SnippetClassifier(npca=None)
+        for snip, lab in snips:
+            sc.add_training_snippets(snip.copy(), label=lab, offset=0)
+            sc2.add_training_snippets(snip.copy(), label=lab, offset=0)
+        sc.fit()
+        sc2.fit()
+        return sc, sc2
+
+    # L = 770 >= n_features (160)  -> covariance_eigh
+    a, b = fit_on([200, 200, 200, 170])
+    assert a.pca_model.n_features_in_ == n_features  # sanity: n_features = T*M = 160
+    assert a.pca_model._fit_svd_solver == "covariance_eigh"
+    assert np.array_equal(a.pca_model.components_, b.pca_model.components_)  # bit-reproducible
+
+    # L = 100 < n_features (160)  -> full
+    c, d = fit_on([100])
+    assert c.pca_model._fit_svd_solver == "full"
+    assert np.array_equal(c.pca_model.components_, d.pca_model.components_)
+
+    # never the stochastic solver
+    assert a.pca_model._fit_svd_solver != "randomized"
+    assert c.pca_model._fit_svd_solver != "randomized"
+
+
+def test_deterministic_pca_solver_selection():
+    from mountainsort5.core.pca_solver import deterministic_pca_solver
+    assert deterministic_pca_solver(5000, 160) == "covariance_eigh"   # L >= D, D <= cap (tetrode-like)
+    assert deterministic_pca_solver(100, 160) == "full"               # L < D, D <= cap
+    assert deterministic_pca_solver(272000, 21120) == "randomized"    # D > cap (NP whole-probe phase-1)
+    assert deterministic_pca_solver(9000, 8000) == "covariance_eigh"  # at the cap, L >= D
+    assert deterministic_pca_solver(9000, 8001) == "randomized"       # just over the cap
+
+
+def test_compute_pca_features_is_deterministic():
+    # compute_pca_features must be reproducible run-to-run in BOTH regimes:
+    # exact 'covariance_eigh'/'full' for modest n_features, and SEEDED 'randomized'
+    # for large n_features (the whole-probe phase-1 case). sklearn's unseeded 'auto'
+    # randomized would not be.
+    from mountainsort5.core.compute_pca_features import compute_pca_features
+    rng = np.random.default_rng(2)
+    # exact regime (D <= cap)
+    X_small = rng.standard_normal((2000, 200)).astype(np.float32)
+    assert np.array_equal(compute_pca_features(X_small, npca=30), compute_pca_features(X_small, npca=30))
+    # large-D randomized regime (D > cap) -> seeded, so still bit-reproducible
+    X_large = rng.standard_normal((300, 8200)).astype(np.float32)
+    assert np.array_equal(compute_pca_features(X_large, npca=20), compute_pca_features(X_large, npca=20))


### PR DESCRIPTION
See discussion in #53 . 
Additionally, I confirmed on a 48h continuous 64ch recording (tetrodes) that this produces identical scheme 3 sortings run-to-run! 